### PR TITLE
Drop :remove from Windows + add Debian support

### DIFF
--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -1,8 +1,10 @@
 ---
 driver:
-  name: localhost
+  name: digitalocean
 
 platforms:
   - name: macosx
     driver:
       name: localhost
+  - name: ubuntu-14-04-x64
+  - name: debian-7-0-x64

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,6 +14,8 @@ platforms:
   - name: windows-8
     driver:
       box: roboticcheese/windows-8
+  - name: ubuntu-14.04
+  - name: debian-7.8
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,3 +23,5 @@ suites:
   - name: uninstall
     run_list:
       - recipe[spotify_test::uninstall]
+    excludes:
+      - windows-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ install:
 before_script:
   # Pending ENV support in Kitchen's Rake tasks and not just the CLI
   - cp .kitchen.travis.yml .kitchen.local.yml
+  - echo -e $DIGITALOCEAN_SSH_KEY_BODY > ~/.ssh/id_rsa
 
 script:
-  - chef exec rake && chef exec rake kitchen:all
+  - chef exec rake && chef exec kitchen test -c 4
 
 after_script:
+  - chef exec kitchen destroy
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - echo -e $DIGITALOCEAN_SSH_KEY_BODY > ~/.ssh/id_rsa
 
 script:
-  - chef exec rake && chef exec kitchen test -c 4
+  - chef exec rake && chef exec kitchen test macosx && chef exec kitchen test x64 -c 4
 
 after_script:
   - chef exec kitchen destroy

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :test do
   gem 'fauxhai'
   gem 'test-kitchen'
   gem 'winrm-transport'
+  gem 'kitchen-digitalocean'
   gem 'kitchen-localhost'
   gem 'kitchen-vagrant'
 end

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ A Chef cookbook for Spotify.
 Requirements
 ============
 
-This cookbook supports both OS X and Windows.
+This cookbook supports both OS X and Windows, as well as Spotify's unsupported
+packages for Ubuntu/Debian.
 
 Usage
 =====
@@ -69,6 +70,10 @@ Provider for Max OS X platforms.
 ***Chef::Provider::SpotifyApp::Windows***
 
 Provider for Windows platforms.
+
+***Chef::Provider::SpotifyApp::Debian***
+
+Provider for Ubuntu and Debian platforms.
 
 ***Chef::Provider::SpotifyApp***
 

--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ Syntax:
 
 Actions:
 
-| Action     | Description       |
-|------------|-------------------|
-| `:install` | Install the app   |
-| `:remove`  | Uninstall the app |
+| Action     | Description         |
+|------------|---------------------|
+| `:install` | Install the app     |
+| `:remove`  | Uninstall the app\* |
+
+_\* The remove action is not supported under Windows--the uninstaller has no
+silent/unattended option._
 
 Attributes:
 

--- a/libraries/provider_mapping.rb
+++ b/libraries/provider_mapping.rb
@@ -28,3 +28,9 @@ Chef::Platform.set(platform: :mac_os_x,
 Chef::Platform.set(platform: :windows,
                    resource: :spotify_app,
                    provider: Chef::Provider::SpotifyApp::Windows)
+Chef::Platform.set(platform: :ubuntu,
+                   resource: :spotify_app,
+                   provider: Chef::Provider::SpotifyApp::Debian)
+Chef::Platform.set(platform: :debian,
+                   resource: :spotify_app,
+                   provider: Chef::Provider::SpotifyApp::Debian)

--- a/libraries/provider_spotify_app.rb
+++ b/libraries/provider_spotify_app.rb
@@ -22,6 +22,7 @@ require 'chef/provider/lwrp_base'
 require_relative 'resource_spotify_app'
 require_relative 'provider_spotify_app_mac_os_x'
 require_relative 'provider_spotify_app_windows'
+require_relative 'provider_spotify_app_debian'
 
 class Chef
   class Provider

--- a/libraries/provider_spotify_app_debian.rb
+++ b/libraries/provider_spotify_app_debian.rb
@@ -19,6 +19,7 @@
 #
 
 require 'chef/provider/lwrp_base'
+require 'chef/dsl/include_recipe'
 require_relative 'provider_spotify_app'
 
 class Chef
@@ -28,6 +29,8 @@ class Chef
       #
       # @author Jonathan Hartman <j@p4nt5.com>
       class Debian < SpotifyApp
+        include Chef::DSL::IncludeRecipe
+
         # No URL or PATH--everything is handled by APT
 
         private
@@ -40,13 +43,7 @@ class Chef
         # (see SpotifyApp#install!)
         #
         def install!
-          apt_repository 'spotify' do
-            uri 'http://repository.spotify.com'
-            components %w(stable non-free)
-            key '94558F59'
-            keyserver 'keyserver.ubuntu.com'
-            action :add
-          end
+          add_repo
           package 'spotify-client' do
             action :install
           end
@@ -64,6 +61,21 @@ class Chef
           end
           apt_repository 'spotify' do
             action :remove
+          end
+        end
+
+        #
+        # Configure Spotify's APT repository, making sure APT's cache is
+        # updated as well.
+        #
+        def add_repo
+          include_recipe 'apt'
+          apt_repository 'spotify' do
+            uri 'http://repository.spotify.com'
+            components %w(stable non-free)
+            key '94558F59'
+            keyserver 'keyserver.ubuntu.com'
+            action :add
           end
         end
       end

--- a/libraries/provider_spotify_app_debian.rb
+++ b/libraries/provider_spotify_app_debian.rb
@@ -1,0 +1,72 @@
+# Encoding: UTF-8
+#
+# Cookbook Name:: spotify
+# Library:: provider_spotify_app_debian
+#
+# Copyright 2015 Jonathan Hartman
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider/lwrp_base'
+require_relative 'provider_spotify_app'
+
+class Chef
+  class Provider
+    class SpotifyApp < Provider::LWRPBase
+      # An provider for Spotify on Mac OS X.
+      #
+      # @author Jonathan Hartman <j@p4nt5.com>
+      class Debian < SpotifyApp
+        # No URL or PATH--everything is handled by APT
+
+        private
+
+        #
+        # Set up Spotify's APT repository and install their Debian package,
+        # as documented at:
+        #   https://www.spotify.com/us/download/previews
+        #
+        # (see SpotifyApp#install!)
+        #
+        def install!
+          apt_repository 'spotify' do
+            uri 'http://repository.spotify.com'
+            components %w(stable non-free)
+            key '94558F59'
+            keyserver 'keyserver.ubuntu.com'
+            action :add
+          end
+          package 'spotify-client' do
+            action :install
+          end
+        end
+
+        #
+        # Remove Spotify's Debian package and delete their APT repo (should be
+        # safe since it's strictly a repo for Spotify packages).
+        #
+        # (see SpotifyApp#remove!)
+        #
+        def remove!
+          package 'spotify-client' do
+            action :remove
+          end
+          apt_repository 'spotify' do
+            action :remove
+          end
+        end
+      end
+    end
+  end
+end

--- a/libraries/provider_spotify_app_windows.rb
+++ b/libraries/provider_spotify_app_windows.rb
@@ -44,21 +44,6 @@ class Chef
         end
 
         #
-        # Uninstall the package and cleanup whatever is left behind.
-        #
-        # (see SpotifyApp#remove!)
-        #
-        def remove!
-          windows_package 'Spotify' do
-            action :remove
-          end
-          directory PATH do
-            recursive true
-            action :delete
-          end
-        end
-
-        #
         # Use a windows_package resource to install the .exe file.
         #
         def install_package

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,7 +11,10 @@ version          '0.0.1'
 
 depends          'dmg', '~> 2.2'
 depends          'windows', '~> 1.37'
+depends          'apt', '~> 2.7'
 
 supports         'mac_os_x'
 supports         'windows'
+supports         'ubuntu'
+supports         'debian'
 # rubocop:enable SingleSpaceBeforeFirstArg

--- a/spec/libraries/provider_mapping_spec.rb
+++ b/spec/libraries/provider_mapping_spec.rb
@@ -21,13 +21,29 @@ describe 'spotify::provider_mapping' do
   context 'Windows' do
     let(:platform) { :windows }
 
-    it 'returns no app provider' do
+    it 'uses the Windows app provider' do
       expect(app_provider).to eq(Chef::Provider::SpotifyApp::Windows)
     end
   end
 
   context 'Ubuntu' do
     let(:platform) { :ubuntu }
+
+    it 'uses the Debian app provider' do
+      expect(app_provider).to eq(Chef::Provider::SpotifyApp::Debian)
+    end
+  end
+
+  context 'Debian' do
+    let(:platform) { :debian }
+
+    it 'uses the Debian app provider' do
+      expect(app_provider).to eq(Chef::Provider::SpotifyApp::Debian)
+    end
+  end
+
+  context 'CentOS' do
+    let(:platform) { :centos }
 
     it 'returns no app provider' do
       expect(app_provider).to eq(nil)

--- a/spec/libraries/provider_spotify_app_debian_spec.rb
+++ b/spec/libraries/provider_spotify_app_debian_spec.rb
@@ -1,0 +1,36 @@
+# Encoding: UTF-8
+
+require_relative '../spec_helper'
+require_relative '../../libraries/provider_spotify_app_debian'
+
+describe Chef::Provider::SpotifyApp::Debian do
+  let(:name) { 'default' }
+  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, nil) }
+  let(:provider) { described_class.new(new_resource, nil) }
+
+  describe '#install!' do
+    it 'uses an apt_repository and package to install Spotify' do
+      p = provider
+      expect(p).to receive(:apt_repository).with('spotify').and_yield
+      expect(p).to receive(:uri).with('http://repository.spotify.com')
+      expect(p).to receive(:components).with(%w(stable non-free))
+      expect(p).to receive(:key).with('94558F59')
+      expect(p).to receive(:keyserver).with('keyserver.ubuntu.com')
+      expect(p).to receive(:action).with(:add)
+      expect(p).to receive(:package).with('spotify-client').and_yield
+      expect(p).to receive(:action).with(:install)
+      p.send(:install!)
+    end
+  end
+
+  describe '#remove!' do
+    it 'uses a package and apt_repository to delete Spotify' do
+      p = provider
+      expect(p).to receive(:package).with('spotify-client').and_yield
+      expect(p).to receive(:action).with(:remove)
+      expect(p).to receive(:apt_repository).with('spotify').and_yield
+      expect(p).to receive(:action).with(:remove)
+      p.send(:remove!)
+    end
+  end
+end

--- a/spec/libraries/provider_spotify_app_debian_spec.rb
+++ b/spec/libraries/provider_spotify_app_debian_spec.rb
@@ -9,14 +9,9 @@ describe Chef::Provider::SpotifyApp::Debian do
   let(:provider) { described_class.new(new_resource, nil) }
 
   describe '#install!' do
-    it 'uses an apt_repository and package to install Spotify' do
+    it 'configures the Spotify APT repo and installs the package' do
       p = provider
-      expect(p).to receive(:apt_repository).with('spotify').and_yield
-      expect(p).to receive(:uri).with('http://repository.spotify.com')
-      expect(p).to receive(:components).with(%w(stable non-free))
-      expect(p).to receive(:key).with('94558F59')
-      expect(p).to receive(:keyserver).with('keyserver.ubuntu.com')
-      expect(p).to receive(:action).with(:add)
+      expect(p).to receive(:add_repo)
       expect(p).to receive(:package).with('spotify-client').and_yield
       expect(p).to receive(:action).with(:install)
       p.send(:install!)
@@ -31,6 +26,20 @@ describe Chef::Provider::SpotifyApp::Debian do
       expect(p).to receive(:apt_repository).with('spotify').and_yield
       expect(p).to receive(:action).with(:remove)
       p.send(:remove!)
+    end
+  end
+
+  describe '#add_repo' do
+    it 'configures the Spotify APT repository' do
+      p = provider
+      expect(p).to receive(:include_recipe).with('apt')
+      expect(p).to receive(:apt_repository).with('spotify').and_yield
+      expect(p).to receive(:uri).with('http://repository.spotify.com')
+      expect(p).to receive(:components).with(%w(stable non-free))
+      expect(p).to receive(:key).with('94558F59')
+      expect(p).to receive(:keyserver).with('keyserver.ubuntu.com')
+      expect(p).to receive(:action).with(:add)
+      p.send(:add_repo)
     end
   end
 end

--- a/spec/libraries/provider_spotify_app_windows_spec.rb
+++ b/spec/libraries/provider_spotify_app_windows_spec.rb
@@ -26,26 +26,9 @@ describe Chef::Provider::SpotifyApp::Windows do
     end
   end
 
-  describe '#remove!' do
-    before(:each) do
-      [:windows_package, :directory].each do |r|
-        allow_any_instance_of(described_class).to receive(r)
-      end
-    end
-
-    it 'removes the package' do
-      p = provider
-      expect(p).to receive(:windows_package).with('Spotify').and_yield
-      expect(p).to receive(:action).with(:remove)
-      p.send(:remove!)
-    end
-
-    it 'deletes the install dir' do
-      p = provider
-      expect(p).to receive(:directory).with(described_class::PATH).and_yield
-      expect(p).to receive(:recursive).with(true)
-      expect(p).to receive(:action).with(:delete)
-      p.send(:remove!)
+  describe '#remove' do
+    it 'raises an error' do
+      expect { provider.send(:remove!) }.to raise_error(NotImplementedError)
     end
   end
 

--- a/spec/support/cookbooks/apt/metadata.rb
+++ b/spec/support/cookbooks/apt/metadata.rb
@@ -1,0 +1,11 @@
+# Encoding: UTF-8
+#
+# rubocop:disable SingleSpaceBeforeFirstArg
+name             'apt'
+maintainer       'test'
+maintainer_email 'example@example.com'
+license          'apache2'
+description      'apt'
+long_description 'apt'
+version          '0.0.1'
+# rubocop:enable SingleSpaceBeforeFirstArg

--- a/test/integration/default/serverspec/localhost/app_spec.rb
+++ b/test/integration/default/serverspec/localhost/app_spec.rb
@@ -21,4 +21,18 @@ describe 'spotify::app' do
       expect(subject).to be_directory
     end
   end
+
+  describe file('/etc/apt/sources.list.d/spotify.list'),
+           if: %w(ubuntu debian).include?(os[:family]) do
+    it 'exists' do
+      expect(subject).to be_file
+    end
+  end
+
+  describe file('/usr/bin/spotify'),
+           if: %w(ubuntu debian).include?(os[:family]) do
+    it 'exists and is executable' do
+      expect(subject).to be_executable
+    end
+  end
 end

--- a/test/integration/uninstall/serverspec/localhost/app_spec.rb
+++ b/test/integration/uninstall/serverspec/localhost/app_spec.rb
@@ -21,4 +21,18 @@ describe 'spotify::app' do
       expect(subject).not_to be_directory
     end
   end
+
+  describe file('/etc/apt/sources.list.d/spotify.list'),
+           if: %w(ubuntu debian).include?(os[:family]) do
+    it 'does not exist' do
+      expect(subject).not_to be_file
+    end
+  end
+
+  describe file('/usr/bin/spotify'),
+           if: %w(ubuntu debian).include?(os[:family]) do
+    it 'does not exist' do
+      expect(subject).not_to be_file
+    end
+  end
 end


### PR DESCRIPTION
There doesn't seem to be a switch that can be passed to the Windows uninstaller that'll suppress the "Are you sure?" prompt.