### PR TITLE
Remove hack for kitchen-localhost threading issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - echo -e $DIGITALOCEAN_SSH_KEY_BODY > ~/.ssh/id_rsa
 
 script:
-  - chef exec rake && chef exec kitchen test macosx && chef exec kitchen test x64 -c 4
+  - chef exec rake && chef exec kitchen test -c 6
 
 after_script:
   - chef exec kitchen destroy


### PR DESCRIPTION
The latest release of kitchen-localhost adds a Mutex to prevent suites from stomping on each other.