### PR TITLE
Update to new APT repo key

### DIFF
--- a/libraries/provider_spotify_app_debian.rb
+++ b/libraries/provider_spotify_app_debian.rb
@@ -75,7 +75,7 @@ class Chef
           apt_repository 'spotify' do
             uri 'http://repository.spotify.com'
             components %w(stable non-free)
-            key '94558F59'
+            key 'D2C19886'
             keyserver 'keyserver.ubuntu.com'
             action :add
           end

--- a/spec/libraries/provider_spotify_app_debian_spec.rb
+++ b/spec/libraries/provider_spotify_app_debian_spec.rb
@@ -55,7 +55,7 @@ describe Chef::Provider::SpotifyApp::Debian do
       expect(p).to receive(:apt_repository).with('spotify').and_yield
       expect(p).to receive(:uri).with('http://repository.spotify.com')
       expect(p).to receive(:components).with(%w(stable non-free))
-      expect(p).to receive(:key).with('94558F59')
+      expect(p).to receive(:key).with('D2C19886')
       expect(p).to receive(:keyserver).with('keyserver.ubuntu.com')
       expect(p).to receive(:action).with(:add)
       p.send(:add_repo)


### PR DESCRIPTION
Looks like they changed their APT repo key--the Ubuntu builds were failing.