### PR TITLE
Update tests

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -4,4 +4,4 @@ driver:
   clean_up_on_destroy: false
 
 platforms:
-  - name: macosx
+  - name: windows

--- a/.kitchen.circle.yml
+++ b/.kitchen.circle.yml
@@ -1,0 +1,9 @@
+---
+driver:
+  name: docker
+  privileged: true
+
+platforms:
+  - name: ubuntu-15.04
+  - name: ubuntu-14.04
+  - name: debian-8.2

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,8 +14,9 @@ platforms:
   - name: windows-8
     driver:
       box: roboticcheese/windows-8
+  - name: ubuntu-15.04
   - name: ubuntu-14.04
-  - name: debian-7.8
+  - name: debian-8.2
 
 suites:
   - name: default
@@ -27,3 +28,4 @@ suites:
       - recipe[spotify_test::uninstall]
     excludes:
       - windows-8
+      - windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: objective-c
 
+branches:
+  only:
+    - master
+
 install:
   - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
   - chef exec bundle install --without=development integration
@@ -7,13 +11,11 @@ install:
 before_script:
   # Pending ENV support in Kitchen's Rake tasks and not just the CLI
   - cp .kitchen.travis.yml .kitchen.local.yml
-  - echo -e $DIGITALOCEAN_SSH_KEY_BODY > ~/.ssh/id_rsa
 
 script:
-  - chef exec rake && chef exec kitchen test -c 6
+  - chef exec kitchen test
 
 after_script:
-  - chef exec kitchen destroy
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Spotify Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Update to newer provider resolver style
+- Update to new repo key used for Ubuntu/Debian installs
 
 v0.1.0 (2015-05-26)
 -------------------

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :test do
   gem 'kitchen-digitalocean'
   gem 'kitchen-localhost'
   gem 'kitchen-vagrant'
+  gem 'kitchen-docker'
 end
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 Spotify Cookbook
 ================
 [![Cookbook Version](https://img.shields.io/cookbook/v/spotify.svg)][cookbook]
-[![Build Status](https://img.shields.io/travis/RoboticCheese/spotify-chef.svg)][travis]
+[![Linux Build Status](https://img.shields.io/circleci/project/RoboticCheese/spotify-chef.svg)][circle]
+[![OS X Build Status](https://img.shields.io/travis/RoboticCheese/spotify-chef.svg)][travis]
+[![Windows Build Status](https://img.shields.io/appveyor/ci/RoboticCheese/spotify-chef.svg)][appveyor]
 [![Code Climate](https://img.shields.io/codeclimate/github/RoboticCheese/spotify-chef.svg)][codeclimate]
 [![Coverage Status](https://img.shields.io/coveralls/RoboticCheese/spotify-chef.svg)][coveralls]
 
 [cookbook]: https://supermarket.chef.io/cookbooks/spotify
+[circle]: https://circleci.com/gh/RoboticCheese/spotify-chef
 [travis]: https://travis-ci.org/RoboticCheese/spotify-chef
+[appveyor]: https://ci.appveyor.com/project/RoboticCheese/spotify-chef
 [codeclimate]: https://codeclimate.com/github/RoboticCheese/spotify-chef
 [coveralls]: https://coveralls.io/r/RoboticCheese/spotify-chef
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+branches:
+  only:
+    - master
+
+cache:
+  - '%TEMP%\verifier\gems'
+
+install:
+  - cinst chefdk
+  - SET PATH=C:\opscode\chefdk\bin;%PATH%
+
+build_script:
+  - chef exec bundle install --without=development integration
+  - copy .kitchen.appveyor.yml .kitchen.local.yml
+
+test_script:
+  - chef exec kitchen test

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,24 @@
+machine:
+  ruby:
+    version: 2.1.6
+  services:
+    - docker
+
+dependencies:
+  pre:
+    - rvm install 2.0.0-p645
+  override:
+    - gem install -V berkshelf
+    - rvm-exec 2.0.0-p645 gem install -V berkshelf
+    - bundle install --without=development integration
+    - rvm-exec 2.0.0-p645 bundle install --without=development integration
+  cache_directories:
+    - /home/ubuntu/.rvm/gems
+
+test:
+  pre:
+    - cp .kitchen.circle.yml .kitchen.local.yml
+  override:
+    - bundle exec rake
+    - rvm-exec 2.0.0-p645 bundle exec rake
+    - bundle exec kitchen verify

--- a/spec/libraries/provider_spotify_app_debian_spec.rb
+++ b/spec/libraries/provider_spotify_app_debian_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_spotify_app_debian'
 
 describe Chef::Provider::SpotifyApp::Debian do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_spotify_app_mac_os_x_spec.rb
+++ b/spec/libraries/provider_spotify_app_mac_os_x_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_spotify_app_mac_os_x'
 
 describe Chef::Provider::SpotifyApp::MacOsX do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }

--- a/spec/libraries/provider_spotify_app_spec.rb
+++ b/spec/libraries/provider_spotify_app_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_spotify_app'
 
 describe Chef::Provider::SpotifyApp do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '#whyrun_supported?' do
     it 'returns true' do

--- a/spec/libraries/provider_spotify_app_windows_spec.rb
+++ b/spec/libraries/provider_spotify_app_windows_spec.rb
@@ -5,8 +5,9 @@ require_relative '../../libraries/provider_spotify_app_windows'
 
 describe Chef::Provider::SpotifyApp::Windows do
   let(:name) { 'default' }
-  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, nil) }
-  let(:provider) { described_class.new(new_resource, nil) }
+  let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
+  let(:new_resource) { Chef::Resource::SpotifyApp.new(name, run_context) }
+  let(:provider) { described_class.new(new_resource, run_context) }
 
   describe '.provides?' do
     let(:platform) { nil }
@@ -81,8 +82,9 @@ describe Chef::Provider::SpotifyApp::Windows do
 
   describe '#download_path' do
     it 'returns a path under the Chef cache dir' do
+      res = provider.send(:download_path)
       expected = "#{Chef::Config[:file_cache_path]}/Spotify.exe"
-      expect(provider.send(:download_path)).to eq(expected)
+      expect(res).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
* Move to the three CI build model for OS X (Travis), Windows (AppVeyor) and Linux (Circle + Docker)
* Update unit tests for Chef 12.5